### PR TITLE
Fixing spiral/attributes version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/cache": "^6.0",
         "symfony/psr-http-message-bridge": "^2",
         "symfony/validator": "^6.0",
-        "spiral/attributes": "^2.8 || ^3.1",
+        "spiral/attributes": "^2.8 || ^3.0",
         "spiral/http": "^3.1"
     },
     "require-dev": {


### PR DESCRIPTION
The spiral/attributes package does not have the 3.1 tag